### PR TITLE
chore: lint/build fixes + test for receipt settings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,9 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      // Deno-based Supabase functions use remote imports and Deno globals; exclude them from
+      // the Next/TypeScript ESLint pipeline to avoid false positives during local lint/build.
+      "supabase/functions/**",
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
     "dev": "next dev",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "@supabase/supabase-js": "^2.56.0",
+    "@types/qrcode": "^1.5.5",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.541.0",
     "next": "15.5.0",
@@ -21,20 +25,19 @@
     "stripe": "^18.5.0",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.8"
-    
-    
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
+    "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^20.19.11",
-    "@types/qrcode": "^1.5.5",
     "@types/nodemailer": "^7.0.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
-  }
+    "typescript": "^5",
+    "vitest": "^1.6.1"
+  },
+  "tw-animate-css": "^1.3.8"
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,7 @@
+import tailwindPostcss from '@tailwindcss/postcss';
+
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: [tailwindPostcss()],
 };
 
 export default config;

--- a/src/shared/templates/receipt-template.test.ts
+++ b/src/shared/templates/receipt-template.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the supabase client import used in the template service
+vi.mock('@/shared/lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({
+            data: {
+              smtp_from_name: null,
+              smtp_from_email: null,
+              association_name: null,
+              association_address: null,
+              association_siren: null,
+              association_rna: null,
+              legal_text: null,
+              enable_tracking: null,
+              template_version: null
+            },
+            error: null
+          })
+        })
+      })
+    })
+  }
+}))
+
+import { ReceiptTemplateService } from './receipt-template'
+
+describe('ReceiptTemplateService.getEmailSettings', () => {
+  it('normalizes nullable DB fields to safe defaults', async () => {
+    const settings = await ReceiptTemplateService.getEmailSettings()
+
+    expect(settings.smtp_from_name).toBeTruthy()
+    expect(settings.smtp_from_email).toContain('@')
+    expect(settings.association_name).toBe('Amicale des Sapeurs-Pompiers')
+    expect(settings.association_address).toBeTruthy()
+    expect(typeof settings.enable_tracking).toBe('boolean')
+    expect(settings.template_version).toBe('v1')
+  })
+})

--- a/src/shared/templates/receipt-template.ts
+++ b/src/shared/templates/receipt-template.ts
@@ -57,25 +57,27 @@ export class ReceiptTemplateService {
       };
     }
 
-    // Normalize and ensure non-nullable fields to match EmailSettings
-    return {
-      smtp_from_name: data.smtp_from_name ?? 'Sapeurs-Pompiers Calendriers 2025',
-      smtp_from_email: data.smtp_from_email ?? 'no-reply@pompiers34800.com',
-      association_name: data.association_name ?? 'Amicale des Sapeurs-Pompiers',
-      association_address: data.association_address ?? 'Adresse à compléter dans les paramètres',
-      association_siren: data.association_siren ?? undefined,
-      association_rna: data.association_rna ?? undefined,
-      legal_text: data.legal_text ?? 'Ce reçu vous est délivré à des fins comptables et justificatives. Conservez-le précieusement.',
-      enable_tracking: Boolean(data.enable_tracking),
-      template_version: String(data.template_version ?? 'v1'),
-    } as EmailSettings;
+    // Normalize nullable DB fields to match EmailSettings (non-nullable strings/booleans)
+    const normalized: EmailSettings = {
+      smtp_from_name: typeof data.smtp_from_name === 'string' && data.smtp_from_name.trim() ? data.smtp_from_name : 'Sapeurs-Pompiers Calendriers 2025',
+      smtp_from_email: typeof data.smtp_from_email === 'string' && data.smtp_from_email.trim() ? data.smtp_from_email : 'no-reply@pompiers34800.com',
+      association_name: typeof data.association_name === 'string' && data.association_name.trim() ? data.association_name : 'Amicale des Sapeurs-Pompiers',
+      association_address: typeof data.association_address === 'string' && data.association_address.trim() ? data.association_address : 'Adresse à compléter dans les paramètres',
+      association_siren: typeof data.association_siren === 'string' && data.association_siren.trim() ? data.association_siren : undefined,
+      association_rna: typeof data.association_rna === 'string' && data.association_rna.trim() ? data.association_rna : undefined,
+      legal_text: typeof data.legal_text === 'string' && data.legal_text.trim() ? data.legal_text : 'Ce reçu vous est délivré à des fins comptables et justificatives. Conservez-le précieusement.',
+      enable_tracking: typeof data.enable_tracking === 'boolean' ? data.enable_tracking : Boolean(data.enable_tracking),
+      template_version: typeof data.template_version === 'string' && data.template_version.trim() ? data.template_version : 'v1'
+    };
+
+    return normalized;
   }
 
   /**
    * Génère l'HTML du reçu avec design émotionnel
    */
   static generateReceiptHTML(data: ReceiptData): string {
-    const paymentMethodLabels: Record<'especes'|'cheque'|'carte'|'virement', string> = {
+    const paymentMethodLabels: Record<string, string> = {
       'especes': '💵 Espèces',
       'cheque': '📝 Chèque',
       'carte': '💳 Carte bancaire',
@@ -475,7 +477,7 @@ export class ReceiptTemplateService {
         
         <div class="detail-row">
           <span class="detail-label">💳 Mode de paiement</span>
-          <span class="detail-value">${paymentMethodLabels[(data.paymentMethod as 'especes'|'cheque'|'carte'|'virement')] || data.paymentMethod}</span>
+          <span class="detail-value">${paymentMethodLabels[data.paymentMethod] || data.paymentMethod}</span>
         </div>
         
         <div class="detail-row">
@@ -542,14 +544,14 @@ export class ReceiptTemplateService {
    * Génère la version texte du reçu
    */
   static generateReceiptText(data: ReceiptData): string {
-    const paymentMethodLabels = {
+    const paymentMethodLabels: Record<string, string> = {
       'especes': 'Espèces',
       'cheque': 'Chèque', 
       'carte': 'Carte bancaire',
       'virement': 'Virement'
     };
 
-  return `
+    return `
 REÇU DE DON - ${data.associationName}
 
 Merci ${data.donatorName} pour votre générosité !
@@ -561,7 +563,7 @@ DÉTAILS DE VOTRE DON
 Donateur      : ${data.donatorName}
 Montant       : ${data.amount}€
 Date          : ${new Date(data.donationDate).toLocaleDateString('fr-FR')}
-Paiement      : ${paymentMethodLabels[(data.paymentMethod as 'especes'|'cheque'|'carte'|'virement')] || data.paymentMethod}
+Paiement      : ${paymentMethodLabels[data.paymentMethod] || data.paymentMethod}
 Calendriers   : ${data.calendarsGiven} calendrier${data.calendarsGiven > 1 ? 's' : ''}
 Sapeur-Pompier: ${data.sapeurName}${data.teamName ? ` (${data.teamName})` : ''}
 N° de reçu    : ${data.receiptNumber}
@@ -594,7 +596,7 @@ Document généré automatiquement le ${new Date().toLocaleDateString('fr-FR')}
 Si vous n'êtes pas le destinataire, veuillez ignorer cet email.
 
 ${data.associationName} - Merci pour votre confiance !
-  `.trim();
+    `.trim();
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions/**"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}']
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  }
+})


### PR DESCRIPTION
This PR makes several small maintenance and safety changes to stabilize the build and add a unit test.

What this PR does:
- Normalize nullable `email_settings` fields returned from the DB so `ReceiptTemplateService.getEmailSettings()` returns safe, non-nullable values and avoids TS errors and runtime undefineds.
- Exclude `supabase/functions/**` from Next.js TypeScript and ESLint checks (they are Deno functions with remote imports and Deno globals).
- Lazy-initialize the Stripe client in the webhook handler so build-time page-data collection doesn't fail when env vars are missing.
- Add Vitest and a unit test for `getEmailSettings()` to assert normalization.
- Fix PostCSS config so Vitest/Vite can load it.

Files changed (high-level):
- src/shared/templates/receipt-template.ts
- tsconfig.json
- eslint.config.mjs
- src/app/api/stripe-webhook/route.ts
- postcss.config.mjs
- package.json
- vitest.config.ts
- src/shared/templates/receipt-template.test.ts
IC notes:
- Run `npm ci` then `npm run build` in CI.
- Tests run with `npm test` (Vitest) and the new test passes locally.

If you want, I can also add a second test covering the DB-error fallback.
